### PR TITLE
added support for running axe without assertions and also using a calback to get the results

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -20,13 +20,12 @@ module.exports = {
   page_objects_path: ['page-objects'],
 
   // See https://nightwatchjs.org/guide/extending-nightwatch/adding-custom-commands.html
-  custom_commands_path: ['nightwatch/commands'],
 
   // See https://nightwatchjs.org/guide/extending-nightwatch/adding-custom-assertions.html
   custom_assertions_path: [],
 
   // See https://nightwatchjs.org/guide/extending-nightwatch/adding-plugins.html
-  // plugins: [],
+  plugins: ['./test_plugin.js'],
 
   // See https://nightwatchjs.org/guide/concepts/test-globals.html
   globals_path: '',

--- a/nightwatch/commands/_axeInjectFn.js
+++ b/nightwatch/commands/_axeInjectFn.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+module.exports = function (selector, options, done) {
+  var axe = window.axe;
+  if (!axe) {
+    done({
+      error: 'aXe not found. Make sure it has been injected',
+    });
+    return;
+  }
+
+  const el = document.querySelector(selector);
+
+  axe.run(el, options, function (err, results) {
+    if (err) {
+      done({
+        error: err.toString(),
+      });
+      return;
+    }
+
+    done({results: results});
+  });
+};

--- a/nightwatch/commands/axeRun.js
+++ b/nightwatch/commands/axeRun.js
@@ -1,53 +1,35 @@
-module.exports.command = function axeRun(selector = 'html', options = {}) {
-  this.executeAsync(
-    // eslint-disable-next-line no-shadow
-    (selector, options, done) => {
-      ((axe) => {
-        if (!axe)
-          done({
-            error: 'aXe not found. Make sure it has been injected',
-          });
-        const el = document.querySelector(selector);
+const axeInjectFn = require('./_axeInjectFn');
 
-        axe.run(el, options, (err, results) => {
-          if (err) {
-            done({
-              error: err.toString(),
-            });
-          }
-          done({
-            results,
-          });
-        });
-      })(window.axe);
-    },
-    [selector, options],
-    (response) => {
-      // eslint-disable-next-line no-unused-vars
-      const { error, results } = response.value;
-
+module.exports = class AxeRun {
+  command(selector = 'html', options = {}, callback = function cb() {}) {
+    this.api.executeAsync(axeInjectFn, [selector, options], (response) => {
+      const runAssertions =
+        options.runAssertions || typeof options.runAssertions === 'undefined';
+      const { results } = response.value;
       const { passes = [], violations = [] } = results;
 
-      for (let i = 0; i < passes.length; i += 1) {
-        this.assert.ok(
-          true,
-          `aXe rule: ${passes[i].id} (${passes[i].nodes.length} elements checked)`
-        );
-      }
+      if (runAssertions) {
+        for (let i = 0; i < passes.length; i += 1) {
+          // eslint-disable-next-line
+          this.api.assert.ok(true, `aXe rule: ${passes[i].id} (${passes[i].nodes.length} elements checked)`);
+        }
 
-      for (let i = 0; i < violations.length; i += 1) {
-        for (let n = 0; n < violations[i].nodes.length; n += 1) {
-          let nodeName = violations[i].nodes[n].target.toString();
-          if (nodeName.length > 100) {
-            nodeName = `...${nodeName.slice(-100)}`;
+        for (let i = 0; i < violations.length; i += 1) {
+          for (let n = 0; n < violations[i].nodes.length; n += 1) {
+            let nodeName = violations[i].nodes[n].target.toString();
+            if (nodeName.length > 100) {
+              nodeName = `...${nodeName.slice(-100)}`;
+            }
+
+            const assertionFailureMessage = `aXe rule: ${violations[i].id} - ${violations[i].help}\r\n\tIn element: ${nodeName}`;
+            this.api.verify.fail(assertionFailureMessage);
           }
-
-          const assertionFailureMessage = `aXe rule: ${violations[i].id} - ${violations[i].help}\r\n\tIn element: ${nodeName}`;
-          this.verify.fail(assertionFailureMessage);
         }
       }
-    }
-  );
 
-  return this;
+      callback(results);
+    });
+
+    return this;
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "mockery": "^2.1.0",
         "nightwatch": "2.3.8",
         "prettier": "^2.7.1"
       }
@@ -2948,12 +2947,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/mockery": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
-      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -6413,12 +6406,6 @@
           }
         }
       }
-    },
-    "mockery": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "nightwatch": "2.3.5",
+        "nightwatch": "^2.3.8",
         "prettier": "^2.7.1"
       }
     },
@@ -2459,6 +2459,12 @@
         "node": ">=v0.10.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2547,36 +2553,6 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/jszip/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
-    },
-    "node_modules/jszip/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/jszip/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/levn": {
@@ -2997,13 +2973,13 @@
       "dev": true
     },
     "node_modules/nightwatch": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-2.3.5.tgz",
-      "integrity": "sha512-Vcb4ARPue4drJkIx1YkZ32ip1sbxvcbgYnJ8gfcoF1ZK3aLJIxBU2pgMYjU+uBc0a72ucB6ZuOYlIxMR1TvUkw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-2.3.8.tgz",
+      "integrity": "sha512-H3rAmV84LW2MTzFnoZsRcqMOR+k8XwQEoA/q2xmffptOkkjO7fJ+xI/74NIeJ0D6IJdyPzU7yj3UrLozsZXuCg==",
       "dev": true,
       "dependencies": {
         "@nightwatch/chai": "5.0.2",
-        "ansi-to-html": "^0.7.2",
+        "ansi-to-html": "0.7.2",
         "assertion-error": "1.1.0",
         "boxen": "5.1.2",
         "chai-nightwatch": "0.5.3",
@@ -3016,19 +2992,20 @@
         "glob": "^7.2.3",
         "lodash.clone": "3.0.3",
         "lodash.defaultsdeep": "4.6.1",
-        "lodash.escape": "^4.0.1",
+        "lodash.escape": "4.0.1",
         "lodash.merge": "4.6.2",
-        "minimatch": "3.0.4",
+        "minimatch": "3.1.2",
         "minimist": "1.2.6",
         "mkpath": "1.0.0",
         "mocha": "9.2.2",
+        "nightwatch-axe-verbose": "2.0.1",
         "open": "^8.4.0",
         "ora": "5.4.1",
-        "selenium-webdriver": "^4.3.1",
+        "selenium-webdriver": "4.3.1",
         "semver": "7.3.5",
-        "stacktrace-parser": "^0.1.10",
+        "stacktrace-parser": "0.1.10",
         "strip-ansi": "6.0.1",
-        "uuid": "^8.3.2"
+        "uuid": "8.3.2"
       },
       "bin": {
         "nightwatch": "bin/nightwatch"
@@ -3053,23 +3030,20 @@
         }
       }
     },
+    "node_modules/nightwatch-axe-verbose": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nightwatch-axe-verbose/-/nightwatch-axe-verbose-2.0.1.tgz",
+      "integrity": "sha512-BoCeEeT94mfjdZtvn3sASDePyAsrdU0GXznaOlMBfAiKrP3Ajy9rQ1YAXLXfoaj0yL9Uy55ZQ7f3tIOJh3/UWw==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "^4.4.3"
+      }
+    },
     "node_modules/nightwatch/node_modules/lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
       "dev": true
-    },
-    "node_modules/nightwatch/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/nightwatch/node_modules/semver": {
       "version": "7.3.5",
@@ -3505,6 +3479,21 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3636,9 +3625,9 @@
       "dev": true
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.4.0.tgz",
-      "integrity": "sha512-Du+/xfpvNi9zHAeYgXhOWN9yH0hph+cuX+hHDBr7d+SbtQVcfNJwBzLsbdHrB1Wh7MHXFuIkSG88A9TRRQUx3g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.3.1.tgz",
+      "integrity": "sha512-TjH/ls1WKRQoFEHcqtn6UtwcLnA3yvx08v9cSSFYvyhp8hJWRtbe9ae2I8uXPisEZ2EaGKKoxBZ4EHv0BJM15g==",
       "dev": true,
       "dependencies": {
         "jszip": "^3.10.0",
@@ -3742,6 +3731,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string.prototype.trimend": {
@@ -4116,9 +4114,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -6001,6 +5999,12 @@
         "is-url": "^1.2.4"
       }
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6075,38 +6079,6 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "levn": {
@@ -6454,13 +6426,13 @@
       "dev": true
     },
     "nightwatch": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-2.3.5.tgz",
-      "integrity": "sha512-Vcb4ARPue4drJkIx1YkZ32ip1sbxvcbgYnJ8gfcoF1ZK3aLJIxBU2pgMYjU+uBc0a72ucB6ZuOYlIxMR1TvUkw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-2.3.8.tgz",
+      "integrity": "sha512-H3rAmV84LW2MTzFnoZsRcqMOR+k8XwQEoA/q2xmffptOkkjO7fJ+xI/74NIeJ0D6IJdyPzU7yj3UrLozsZXuCg==",
       "dev": true,
       "requires": {
         "@nightwatch/chai": "5.0.2",
-        "ansi-to-html": "^0.7.2",
+        "ansi-to-html": "0.7.2",
         "assertion-error": "1.1.0",
         "boxen": "5.1.2",
         "chai-nightwatch": "0.5.3",
@@ -6473,19 +6445,20 @@
         "glob": "^7.2.3",
         "lodash.clone": "3.0.3",
         "lodash.defaultsdeep": "4.6.1",
-        "lodash.escape": "^4.0.1",
+        "lodash.escape": "4.0.1",
         "lodash.merge": "4.6.2",
-        "minimatch": "3.0.4",
+        "minimatch": "3.1.2",
         "minimist": "1.2.6",
         "mkpath": "1.0.0",
         "mocha": "9.2.2",
+        "nightwatch-axe-verbose": "2.0.1",
         "open": "^8.4.0",
         "ora": "5.4.1",
-        "selenium-webdriver": "^4.3.1",
+        "selenium-webdriver": "4.3.1",
         "semver": "7.3.5",
-        "stacktrace-parser": "^0.1.10",
+        "stacktrace-parser": "0.1.10",
         "strip-ansi": "6.0.1",
-        "uuid": "^8.3.2"
+        "uuid": "8.3.2"
       },
       "dependencies": {
         "lodash.escape": {
@@ -6493,15 +6466,6 @@
           "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
           "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
           "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
         },
         "semver": {
           "version": "7.3.5",
@@ -6512,6 +6476,15 @@
             "lru-cache": "^6.0.0"
           }
         }
+      }
+    },
+    "nightwatch-axe-verbose": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nightwatch-axe-verbose/-/nightwatch-axe-verbose-2.0.1.tgz",
+      "integrity": "sha512-BoCeEeT94mfjdZtvn3sASDePyAsrdU0GXznaOlMBfAiKrP3Ajy9rQ1YAXLXfoaj0yL9Uy55ZQ7f3tIOJh3/UWw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^4.4.3"
       }
     },
     "normalize-path": {
@@ -6807,6 +6780,21 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -6887,9 +6875,9 @@
       "dev": true
     },
     "selenium-webdriver": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.4.0.tgz",
-      "integrity": "sha512-Du+/xfpvNi9zHAeYgXhOWN9yH0hph+cuX+hHDBr7d+SbtQVcfNJwBzLsbdHrB1Wh7MHXFuIkSG88A9TRRQUx3g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.3.1.tgz",
+      "integrity": "sha512-TjH/ls1WKRQoFEHcqtn6UtwcLnA3yvx08v9cSSFYvyhp8hJWRtbe9ae2I8uXPisEZ2EaGKKoxBZ4EHv0BJM15g==",
       "dev": true,
       "requires": {
         "jszip": "^3.10.0",
@@ -6971,6 +6959,15 @@
           "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
           "dev": true
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "string.prototype.trimend": {
@@ -7256,9 +7253,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "mockery": "^2.1.0",
     "nightwatch": "2.3.8",
     "prettier": "^2.7.1"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "rimraf ./tests_output/ && npx nightwatch --env headless",
-    "lint": "eslint ./nightwatch/** ./tests/**",
+    "lint": "eslint ./nightwatch/**",
     "lint:fix": "eslint ./nightwatch/** ./tests/** --fix"
   },
   "files": [
@@ -37,7 +37,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "nightwatch": "2.3.5",
+    "nightwatch": "2.3.7",
     "prettier": "^2.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "nightwatch": "2.3.7",
+    "nightwatch": "^2.3.8",
     "prettier": "^2.7.1"
   }
 }

--- a/test_plugin.js
+++ b/test_plugin.js
@@ -1,0 +1,3 @@
+module.exports = {
+  
+}

--- a/tests/canAxeNicely.js
+++ b/tests/canAxeNicely.js
@@ -1,17 +1,42 @@
-module.exports = {
-  afterEach(browser) {
+describe('axe nightwatch integration tests', function() {
+  let assertionsNo = 0;
+
+  afterEach((browser) => {
     browser.end();
-  },
-  'Accessible rule subset will pass on friendly site': (browser) => {
+  });
+
+  it('Accessible rule subset will pass on friendly site', (browser) => {
     browser
       .url('https://www.w3.org/WAI/demos/bad/after/home.html')
       .assert.titleEquals('Welcome to CityLights! [Accessible Home Page]')
       .axeInject()
       .axeRun('body', {
         runOnly: ['color-contrast', 'image-alt'],
+      }, function(results) {
+        browser.assert.ok('violations' in results, 'axe results are available in the callback');
+      }).perform(() => {
+        browser.assert.strictEqual(browser.currentTest.results.assertions.length, 4, 'There are 4 assertons performed');
       });
-  },
-  'Can use command from page objects': (browser) => {
+  });
+
+  it('Run axe without assertions', (browser) => {
+
+    browser
+      .url('https://www.w3.org/WAI/demos/bad/after/home.html')
+      .assert.titleEquals('Welcome to CityLights! [Accessible Home Page]')
+      .axeInject()
+      .axeRun('body', {
+        runAssertions: false,
+        runOnly: ['color-contrast', 'image-alt'],
+      }, function(results) {
+        browser.assert.ok('violations' in results, 'axe results are available in the callback');
+      })
+      .perform(() => {
+        browser.assert.strictEqual(browser.currentTest.results.assertions.length, 2, 'There are 2 assertons performed');
+      });
+  });
+
+  it('Can use command from page objects', (browser) => {
     browser.page
       .home()
       .navigate()
@@ -27,5 +52,5 @@ module.exports = {
           },
         },
       });
-  },
-};
+  });
+});

--- a/tests/canAxeNicely.js
+++ b/tests/canAxeNicely.js
@@ -1,9 +1,7 @@
 describe('axe nightwatch integration tests', function() {
- 
+
   afterEach((browser) => {
     browser.end();
-    mockery.deregisterAll();
-    mockery.disable();
   });
 
   it('Accessible rule subset will pass on friendly site', (browser) => {


### PR DESCRIPTION
This PR adds a few new capabilities:
- pass the `runAssertions` option to be able to skip the Nightwatch assertions altogether
- add a third optional `callback` argument

Other changes:
- refactored the `axeRun()` command as a class
- refactored the test to use the `describe()` interface

I would also recommend to rewrite the axeInject() command and use a script tag element instead of the `eval()`