### PR TITLE
Fixes/use axe command from async function

### DIFF
--- a/nightwatch/commands/_axeInjectFn.js
+++ b/nightwatch/commands/_axeInjectFn.js
@@ -2,9 +2,7 @@
 module.exports = function (selector, options, done) {
   var axe = window.axe;
   if (!axe) {
-    done({
-      error: 'aXe not found. Make sure it has been injected',
-    });
+    done(new Error('aXe not found. Make sure it has been injected'))
     return;
   }
 
@@ -12,12 +10,9 @@ module.exports = function (selector, options, done) {
 
   axe.run(el, options, function (err, results) {
     if (err) {
-      done({
-        error: err.toString(),
-      });
-      return;
+      done(err);
     }
 
-    done({results: results});
+    done(results);
   });
 };

--- a/nightwatch/commands/axeRun.js
+++ b/nightwatch/commands/axeRun.js
@@ -1,11 +1,15 @@
 const axeInjectFn = require('./_axeInjectFn');
 
 module.exports = class AxeRun {
-  command(selector = 'html', options = {}, callback = function cb() {}) {
-    this.api.executeAsync(axeInjectFn, [selector, options], (response) => {
+  async command(selector = 'html', options = {}, callback = function cb() {}) {
+    let returnValue;
+    try {
+      const results = await this.api.executeAsync(axeInjectFn, [
+        selector,
+        options,
+      ]);
       const runAssertions =
         options.runAssertions || typeof options.runAssertions === 'undefined';
-      const { results } = response.value;
       const { passes = [], violations = [] } = results;
 
       if (runAssertions) {
@@ -26,10 +30,14 @@ module.exports = class AxeRun {
           }
         }
       }
-
-      callback(results);
-    });
-
-    return this;
+      returnValue = results;
+    } catch (err) {
+      returnValue = {
+        status: -1,
+        error: err.message,
+      };
+    }
+    callback.call(this.api, returnValue);
+    return returnValue;
   }
 };

--- a/tests/canAxeNicely.js
+++ b/tests/canAxeNicely.js
@@ -74,7 +74,7 @@ describe('axe nightwatch integration tests', () => {
       });
   });
 
-  it(' can use axe command from async function', async (browser) => {
+  it('can use axe command from async function', async (browser) => {
     const results = await browser
       .url('https://www.w3.org/WAI/demos/bad/after/home.html')
       .assert.titleEquals('Welcome to CityLights! [Accessible Home Page]')

--- a/tests/canAxeNicely.js
+++ b/tests/canAxeNicely.js
@@ -73,4 +73,18 @@ describe('axe nightwatch integration tests', () => {
         },
       });
   });
+
+  it(' can use axe command from async function', async (browser) => {
+    const results = await browser
+      .url('https://www.w3.org/WAI/demos/bad/after/home.html')
+      .assert.titleEquals('Welcome to CityLights! [Accessible Home Page]')
+      .axeInject()
+      .axeRun('body', {
+        runOnly: ['color-contrast', 'image-alt'],
+      });
+    browser.assert.ok(
+      'violations' in results,
+      'axe results are available in the result'
+    );
+  });
 });


### PR DESCRIPTION
## Changes
- refactored code to return `results` when called from an async function.
- Example:
```
const results = await browser.axeRun()
```

## Impact
- fixes https://github.com/nightwatchjs/nightwatch/issues/3531
