### PR TITLE
Fix path resolution for axe.min.js

### DIFF
--- a/nightwatch/commands/axeInject.js
+++ b/nightwatch/commands/axeInject.js
@@ -1,35 +1,17 @@
 const fs = require('fs');
 const path = require('path');
 
-const localPath = path.join(
-  __dirname,
-  '..',
-  '..',
-  'node_modules',
-  'axe-core',
-  'axe.min.js'
-);
-const parentPath = path.join(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'axe-core',
-  'axe.min.js'
-);
-
-const axe = fs.existsSync(localPath)
-  ? fs.readFileSync(localPath, 'utf8')
-  : fs.readFileSync(parentPath, 'utf8');
+const axePath = require.resolve('axe-core/axe.min.js');
+const axe = fs.readFileSync(axePath, 'utf8');
 
 module.exports = class AxeInject {
   command() {
     return this.api.execute(
-      (js) => {
-        // eslint-disable-next-line no-eval
-        eval(js);
-      },
-      [axe]
+        (js) => {
+          // eslint-disable-next-line no-eval
+          eval(js);
+        },
+        [axe]
     );
   }
 };

--- a/nightwatch/commands/axeInject.js
+++ b/nightwatch/commands/axeInject.js
@@ -7,11 +7,11 @@ const axe = fs.readFileSync(axePath, 'utf8');
 module.exports = class AxeInject {
   command() {
     return this.api.execute(
-        (js) => {
-          // eslint-disable-next-line no-eval
-          eval(js);
-        },
-        [axe]
+      (js) => {
+        // eslint-disable-next-line no-eval
+        eval(js);
+      },
+      [axe]
     );
   }
 };


### PR DESCRIPTION
The current path resolution doesn't work for package managers that don't use that path scheme (e.g. Yarn > 2). This PR replaces the hard coded path with the correct function for resolving module files.

You can reproduce this error by installing the latest version of Nightwatch with the latest version of Yarn.